### PR TITLE
routine read

### DIFF
--- a/src/api/routine/routineApi.php
+++ b/src/api/routine/routineApi.php
@@ -5,6 +5,7 @@ class RoutineApi extends ApiResourceBase{
         $this->setRoles([
             
             'get' => ['admin', 'Technician', ],
+            'read' => ['admin', 'Technician', ],
             
         ]);
     }
@@ -57,6 +58,28 @@ class RoutineApi extends ApiResourceBase{
             'status' => 'success',
             'count' => count($result),
             'branches' => $result
+        ];
+    }
+
+    public function read($data){
+        $user = $this->getAuthenticatedUser();
+        if (!$user || !$this->checkRoles($user['role_name'], 'read')) {
+            return ['status' => 'error', 'message' => 'Unauthorized'];
+        }
+
+        $missing = $this->validateFields($data, ['routine_id']);
+        if (!empty($missing)) {
+            return ['status' => 'error', 'message' => 'Missing: ' . implode(', ', $missing)];
+        }
+
+        $routine = new Routine($data['routine_id']);
+        if (!$routine->read()) {
+            return ['status' => 'error', 'message' => 'Routine not found'];
+        }
+
+        return [
+            'status' => 'success',
+            'routine' => $routine
         ];
     }
 

--- a/src/classes/Routine.php
+++ b/src/classes/Routine.php
@@ -1,18 +1,22 @@
 <?php
 
 class Routine extends Model {
-    private $id, $name, $address, $latitude, $longitude;
-    private $pdo;
+    public $routine_id;
+    public $planned_date;
+    public $status;
+    public $description;
+    public $response_count;
+    public $branches; // array of branch data
 
-    public function __construct($id, $name = '', $address = '', $latitude = 0, $longitude = 0) {
-        $this->id = $id;
-        $this->name = $name;
-        $this->address = $address;
-        $this->latitude = $latitude;
-        $this->longitude = $longitude;
-
-        
+    public function __construct($routine_id = null, $planned_date = null, $status = 'pending', $description = null, $response_count = 0, $branches = []) {
+        $this->routine_id = $routine_id;
+        $this->planned_date = $planned_date;
+        $this->status = $status;
+        $this->description = $description;
+        $this->response_count = $response_count;
+        $this->branches = $branches;
     }
+
     public static function getNearby($lat, $lng, $radius_km = 10) {
         $conn = DatabaseConnection::getConnection();
         $sql = "SELECT branch_id,client_id,name, address, latitude, longitude
@@ -31,16 +35,27 @@ class Routine extends Model {
     }
 
     public function create() {
-        
         // Implement the logic to create a routine in the database
     }
 
     public function read() {
-    
-
+        $conn = DatabaseConnection::getConnection();
+        $sql = "SELECT * FROM routines WHERE id = :id";
+        $stmt = $conn->prepare($sql);
+        $stmt->bindParam(':id', $this->routine_id);
+        $stmt->execute();
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->routine_id = $result['id'];
+        $this->planned_date = $result['planned_date'];
+        $this->status = $result['status'];
+        $this->description = $result['description'];
+        $this->response_count = $result['response_count'];
+        $this->branches = json_decode($result['branches'], true);
+        return $result['id'] !== null;
     }
 
     public function update() {
+        
         // Implement the logic to update a routine in the database
     }
 


### PR DESCRIPTION
This pull request introduces functionality to read routine data from the database and updates the `Routine` class to support this feature. The changes include adding a new `read` method in the API layer and enhancing the `Routine` class with additional properties and methods for database interaction.

### API Enhancements:
* [`src/api/routine/routineApi.php`](diffhunk://#diff-312b5a4dff2b98265659844e0805fe9fdce1f171f4c553d57e65cd11fb828a67R64-R85): Added a new `read` method to handle routine data retrieval. This method validates user roles, checks required fields, and fetches routine details using the `Routine` class.
* [`src/api/routine/routineApi.php`](diffhunk://#diff-312b5a4dff2b98265659844e0805fe9fdce1f171f4c553d57e65cd11fb828a67R8): Updated the roles configuration to include the `read` permission for `admin` and `Technician` roles.

### Routine Class Updates:
* [`src/classes/Routine.php`](diffhunk://#diff-fa2ac0bf690e022f3b73a2d6a71c895564d05d0cc6f3dc69d25536efdc9d1f59L4-R19): Replaced old properties (`id`, `name`, etc.) with new ones (`routine_id`, `planned_date`, `status`, etc.) to better represent routine data. Updated the constructor to initialize these properties.
* [`src/classes/Routine.php`](diffhunk://#diff-fa2ac0bf690e022f3b73a2d6a71c895564d05d0cc6f3dc69d25536efdc9d1f59L34-R58): Implemented the `read` method to fetch routine data from the database, populate the object's properties, and return whether the routine exists.developed routine read option according to id