### PR TITLE
Add branch and repair read endpoints with details

### DIFF
--- a/src/api/branch/branchApi.php
+++ b/src/api/branch/branchApi.php
@@ -5,11 +5,14 @@ class BranchApi extends ApiResourceBase{
 
             "create_branch" => ["admin","technician"],
             "read_branch" => ["admin","technician"],
+            "read_branch_by_id" => ["admin","technician"],
             "delete_branch" => ["admin"],
             "update_branch_name" => ["admin"],
             "update_branch_contact_person" => ["admin"],
             "update_branch_phone" => ["admin"],
             "update_branch_email" => ["admin"],
+            "readAll_branches" => ["admin","technician"]
+            
         ]);
 
     }
@@ -96,6 +99,75 @@ class BranchApi extends ApiResourceBase{
             ];
         }
     }
+
+        public function read_branch_by_id($data) {
+        $user = $this->getAuthenticatedUser();
+        if(!$user){
+            return [
+                "status" => "error",
+                "message" => "Invalid authentication token"
+            ];
+        }
+        if(!$this->checkRoles($user['role_name'], 'read_branch_by_id')) {
+            return [
+                "status" => "error",
+                "message" => "Unauthorized: Admin or technician access required"
+            ];
+        }
+        $missing = $this->validateFields($data, ['branch_id']);
+        if (!empty($missing)) {
+            return [
+                "status" => "error",
+                "message" => "Invalid Request. Missing fields: " . implode(", ", $missing)
+            ];
+        }
+        $branch = new Branch($data['branch_id']);
+        $success = $branch->read();
+        if ($success) {
+            return [
+                "status" => "success",
+                "data" => $branch
+            ];
+        } else {
+            return [
+                "status" => "error",
+                "message" => "Failed to read branch."
+            ];
+        }
+    } 
+
+
+    public function readAll_branches() {
+        $user = $this->getAuthenticatedUser();
+        if(!$user){
+            return [
+                "status" => "error",
+                "message" => "Invalid authentication token"
+            ];
+        }
+        if(!$this->checkRoles($user['role_name'], 'readAll_branches')) {
+            return [
+                "status" => "error",
+                "message" => "Unauthorized: Admin or technician access required"
+            ];
+        }
+        $branches = Branch::getAllBranchDetails();
+        if ($branches && count($branches) > 0) {
+            return [
+                "status" => "success",
+                "data" => $branches
+            ];
+        } else {
+            return [
+                "status" => "error",
+                "message" => "No branches found."
+            ];
+        }
+    }
+
+
+
+
     public function delete_branch($data){
 
         $user = $this->getAuthenticatedUser();

--- a/src/api/repair/repairApi.php
+++ b/src/api/repair/repairApi.php
@@ -5,6 +5,7 @@ class RepairApi extends ApiResourceBase {
         $this->setRoles([
             "create_repair" => ["admin", "technician"],
             "read_repair" => ["admin", "technician", "user"],
+            "read_all_repairs" => ["admin", "technician", "user"],
             "update_repair" => ["admin", "technician"],
             "delete_repair" => ["admin"]
         ]);
@@ -25,7 +26,8 @@ class RepairApi extends ApiResourceBase {
             ];
         }
 
-        $missing = $this->validateFields($data, ['device_type', 'device_id', 'branch_id', 'technician_id', 'start_time']);
+        $missing = $this->validateFields($data, ['device_type', 'device_id', 'branch_id', 'technician_id', 'start_time', 'virtual_support_link']);
+         // Ensure all required fields are present
         if (!empty($missing)) {
             return [
                 "status" => "error",
@@ -33,7 +35,7 @@ class RepairApi extends ApiResourceBase {
             ];
         }
 
-        $repair = new Repair(null, $data['device_type'], $data['device_id'], $data['branch_id'], $data['technician_id'], $data['start_time']);
+        $repair = new Repair(null, $data['device_type'], $data['device_id'], $data['branch_id'], $data['technician_id'], $data['start_time'],null,null,null, $data['virtual_support_link']);
         $success = $repair->create();
 
         if ($success) {
@@ -79,12 +81,61 @@ class RepairApi extends ApiResourceBase {
         if ($success) {
             return [
                 "status" => "success",
-                "data" => $repair
+                "data" => [
+                    "repair_id" => $repair->repair_id,
+                    "device_type" => $repair->device_type,
+                    "device_id" => $repair->device_id,
+                    "branch_id" => $repair->branch_id,
+                    "branch_name" => $repair->branch_name,
+                    "technician_id" => $repair->technician_id,
+                    "technician_name" => $repair->technician_name,
+                    "start_time" => $repair->start_time,
+                    "end_time" => $repair->end_time,
+                    "status" => $repair->status,
+                    "summary" => $repair->summary,
+                    "virtual_support_link" => $repair->virtual_support_link,
+                    "backup_sent" => $repair->backup_sent,
+                    "visit_required" => $repair->visit_required
+                ]
             ];
         } else {
             return [
                 "status" => "error",
-                "message" => "Database error: Failed to read repair."
+                "message" => "Repair not found with the provided repair_id."
+            ];
+        }
+    }
+
+    public function read_all_repairs($data) {
+        $user = $this->getAuthenticatedUser();
+        if (!$user) {
+            return [
+                "status" => "error",
+                "message" => "Invalid authentication token"
+            ];
+        }
+        if (!$this->checkRoles($user['role_name'], 'read_all_repairs')) {
+            return [
+                "status" => "error",
+                "message" => "Unauthorized: Admin, Technician or User access required"
+            ];
+        }
+
+        $repair = new Repair();
+        $results = $repair->readAll();
+
+        if ($results && count($results) > 0) {
+            return [
+                "status" => "success",
+                "data" => $results,
+                "count" => count($results)
+            ];
+        } else {
+            return [
+                "status" => "success",
+                "data" => [],
+                "count" => 0,
+                "message" => "No repair records found."
             ];
         }
     }

--- a/src/classes/Branch.php
+++ b/src/classes/Branch.php
@@ -43,9 +43,44 @@ class Branch extends Model{
 
     }
     public function read(){
-        
+
+    $conn = DatabaseConnection::getConnection();
+    $sql = "SELECT * FROM branch WHERE branch_id = :branch_id";
+    $stmt = $conn->prepare($sql);
+    $stmt->bindParam(":branch_id", $this->branch_id);
+    $stmt->execute();
+    $result = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($result) {
+        $this->client_id = $result['client_id'];
+        $this->name = $result['name'];
+        $this->address = $result['address'];
+        $this->latitude = $result['latitude'];
+        $this->longitude = $result['longitude'];
+        $this->location = $result['location'];
+        $this->contact_person = $result['contact_person'];
+        $this->phone = $result['phone'];
+        $this->email = $result['email'];
+        return true;
+    }
+    return false;  
        
     }
+
+    public static function getAllBranchDetails(){
+
+        $conn = DatabaseConnection::getConnection();
+        $sql ="SELECT b.*, c.name AS client_name FROM branch b JOIN client c ON b.client_id = c.client_id";
+        $stmt = $conn->prepare($sql);
+        $stmt->execute();
+        $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return $result;
+
+    }
+
+
+    
+
+
     public function delete(){
         $conn = DatabaseConnection::getConnection();
         $sql = 'DELETE FROM branch WHERE branch_id = :branch_id';
@@ -82,6 +117,20 @@ class Branch extends Model{
         $branches = $stmt->fetchAll(PDO::FETCH_ASSOC);
         return $branches;
     }
+
+    public static function getById($branch_id) {
+        $conn = DatabaseConnection::getConnection();
+        $sql = "SELECT * FROM branch WHERE branch_id = :branch_id";
+        $stmt = $conn->prepare($sql);
+        $stmt->bindParam(":branch_id", $branch_id);
+        $stmt->execute();
+        $branch = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $branch;
+    }
+
+
+
+
     public function updateName($branch_id, $name) {
         $conn = DatabaseConnection::getConnection();
         $sql = 'UPDATE branch SET name = :name WHERE branch_id = :branch_id';

--- a/src/classes/Repair.php
+++ b/src/classes/Repair.php
@@ -12,6 +12,8 @@ class Repair extends Model {
     public $virtual_support_link;
     public $backup_sent;
     public $visit_required;
+    public $technician_name; // Added to store technician name from JOIN
+    public $branch_name; // Added to store branch name from JOIN
 
     public function __construct($repair_id = null, $device_type = null, $device_id = null, $branch_id = null, $technician_id = null, $start_time = null, $end_time = null, $status = null, $summary = null, $virtual_support_link = null, $backup_sent = null, $visit_required = null) {
         $this->repair_id = $repair_id;
@@ -31,7 +33,7 @@ class Repair extends Model {
 public function create(){
 $conn =DatabaseConnection :: getConnection();
 $status = $this->status ?? 'pending';
-$sql ="INSERT INTO repair(device_type,device_id,branch_id,technician_id,start_time,status) VALUES (:device_type, :device_id, :branch_id, :technician_id, :start_time, :status)";
+$sql ="INSERT INTO repair(device_type,device_id,branch_id,technician_id,start_time,status,virtual_support_link) VALUES (:device_type, :device_id, :branch_id, :technician_id, :start_time, :status, :virtual_support_link)";
 $stmt = $conn->prepare($sql);
 $stmt->bindParam("device_type", $this->device_type);
 $stmt->bindParam("device_id", $this->device_id);
@@ -39,36 +41,60 @@ $stmt->bindParam("branch_id", $this->branch_id);
 $stmt->bindParam("technician_id", $this->technician_id);
 $stmt->bindParam("start_time", $this->start_time);
 $stmt->bindParam("status", $status);
+$stmt->bindParam("virtual_support_link", $this->virtual_support_link);
 $success = $stmt->execute();
 return $success;
 
 }
 
 public function read(){
-  $conn =DatabaseConnection :: getConnection();
-  $sql ="SELECT * FROM repair WHERE repair_id =:repair_id;";
+  $conn = DatabaseConnection::getConnection();
+  $sql = "SELECT r.*, u.username as technician_name, b.name as branch_name 
+          FROM repair r 
+          LEFT JOIN users u ON r.technician_id = u.user_id 
+          LEFT JOIN branch b ON r.branch_id = b.branch_id 
+          WHERE r.repair_id = :repair_id";
   $stmt = $conn->prepare($sql);
   $stmt->bindParam("repair_id", $this->repair_id);
   $stmt->execute();
- $result = $stmt->fetch(PDO::FETCH_ASSOC);
+  $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
-$this->device_type = $result['device_type'];
-$this->device_id = $result['device_id'];
-$this->branch_id = $result['branch_id'];
-$this->technician_id = $result['technician_id'];
-$this->start_time = $result['start_time'];
-$this->end_time = $result['end_time'];
-$this->status = $result['status'];
-$this->summary = $result['summary'];
-$this->virtual_support_link = $result['virtual_support_link'];
-$this->backup_sent = $result['backup_sent'];
-$this->visit_required = $result['visit_required'];
-return $result['repair_id'] !== null; 
-
+  if ($result) {
+    $this->device_type = $result['device_type'];
+    $this->device_id = $result['device_id'];
+    $this->branch_id = $result['branch_id'];
+    $this->technician_id = $result['technician_id'];
+    $this->start_time = $result['start_time'];
+    $this->end_time = $result['end_time'];
+    $this->status = $result['status'];
+    $this->summary = $result['summary'];
+    $this->virtual_support_link = $result['virtual_support_link'];
+    $this->backup_sent = $result['backup_sent'];
+    $this->visit_required = $result['visit_required'];
+    $this->technician_name = $result['technician_name'];
+    $this->branch_name = $result['branch_name'];
+    return true;
+  }
+  return false;
 }
+
+public function readAll(){
+  $conn = DatabaseConnection::getConnection();
+  $sql = "SELECT r.*, u.username as technician_name, b.name as branch_name 
+          FROM repair r 
+          LEFT JOIN users u ON r.technician_id = u.user_id 
+          LEFT JOIN branch b ON r.branch_id = b.branch_id 
+          ORDER BY r.repair_id DESC";
+  $stmt = $conn->prepare($sql);
+  $stmt->execute();
+  $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+  
+  return $results;
+}
+
 public function update(){
 $conn = DatabaseConnection::getConnection();
-// Fixed SQL syntax: removed 'FROM'
+
 $sql =  'UPDATE repair SET status = :status, end_time = :end_time, summary = :summary, virtual_support_link = :virtual_support_link, backup_sent = :backup_sent, visit_required = :visit_required WHERE repair_id = :repair_id';
 $stmt = $conn->prepare($sql);
 $stmt->bindParam(':repair_id', $this->repair_id);


### PR DESCRIPTION
Introduces read_branch_by_id and readAll_branches endpoints in BranchApi, with supporting methods in Branch.php for fetching branch details. Adds read_all_repairs endpoint in RepairApi and implements detailed repair fetching with technician and branch names in Repair.php. Also updates repair creation to include virtual_support_link and ensures all relevant fields are handled.