### PR TITLE
Add admin endpoints for bulk update and retrieval

### DIFF
--- a/src/api/Installation/InstallationApi.php
+++ b/src/api/Installation/InstallationApi.php
@@ -12,6 +12,7 @@
             "update_notes" => ["admin", "technician"],
             "delete_installation" => ["admin"],
             "view_all_installations" => ["admin"],
+            "update_all_installations" => ["admin"],
         ]);
     }
     public function create_installation($data) {
@@ -30,7 +31,7 @@
             ];
         }
 
-        $missing = $this->validateFields($data, ["chdm_id", "branch_id", "status", "date", "software_version", "ip_address","notes"]);
+        $missing = $this->validateFields($data, ["branch_id", "status", "date", "software_version", "ip_address", "notes", "serial_no"]);
         if (!empty($missing)) {
             return [
                 "message" => "Missing required fields: " . implode(", ", $missing),
@@ -39,9 +40,8 @@
         }
 
         // Get technician_id from JWT token
-        // Debug: Check what's in the user array
         error_log("User data: " . print_r($user, true));
-        
+
         // Try different possible key names for user ID
         $technician_id = null;
         if (isset($user['user_id'])) {
@@ -51,7 +51,7 @@
         } elseif (isset($user['uid'])) {
             $technician_id = $user['uid'];
         }
-        
+
         if (!$technician_id) {
             return [
                 "message" => "Unable to identify technician from token",
@@ -59,16 +59,67 @@
             ];
         }
 
-        $installation = new Installation(null, $data['chdm_id'], $data['branch_id'], $technician_id, $data['status'], $data['date'], $data['software_version'], $data['ip_address'], $data['notes']);
-          $success = $installation->create();
+        // Find chdm_id from not assigned chdm list by serial_no
+        $chdm_id = null;
+        if (!empty($data['serial_no'])) {
+            if (!class_exists('Chdm')) {
+                include_once __DIR__ . '/../../classes/Chdm.php';
+            }
+            $notAssignedChdms = call_user_func(['Chdm', 'getNotAssigned']);
+            if (is_array($notAssignedChdms)) {
+                foreach ($notAssignedChdms as $chdm) {
+                    if (isset($chdm['serial_no']) && $chdm['serial_no'] == $data['serial_no']) {
+                        // Use 'id' or 'chdm_id' depending on your schema
+                        $chdm_id = isset($chdm['id']) ? $chdm['id'] : (isset($chdm['chdm_id']) ? $chdm['chdm_id'] : null);
+                        break;
+                    }
+                }
+            }
+        }
 
-          if ($success) {
+        if ($chdm_id === null) {
             return [
-                 "status" => "success",
-                "message" => "Installation created successfully"
-               
+                "message" => "No not assigned CHDM found with the given serial_no.",
+                "status" => "error"
             ];
-    }else {
+        }
+
+        $installation = new Installation(
+            null,
+            $chdm_id,
+            $data['branch_id'],
+            $technician_id,
+            $data['status'],
+            $data['date'],
+            null,
+            $data['software_version'],
+            $data['ip_address'],
+            $data['notes'],
+            $data['serial_no']
+        );
+        $success = $installation->create();
+
+        if ($success) {
+            // Assign the CHDM to the branch in chdm table
+            if (!class_exists('Chdm')) {
+                include_once __DIR__ . '/../../classes/Chdm.php';
+            }
+            $assignSuccess = false;
+            if (method_exists('Chdm', 'assignForBranch')) {
+                $assignSuccess = call_user_func(['Chdm', 'assignForBranch'], $data['serial_no'], $data['branch_id']);
+            }
+            if ($assignSuccess) {
+                return [
+                    "status" => "success",
+                    "message" => "Installation created and CHDM assigned to branch successfully"
+                ];
+            } else {
+                return [
+                    "status" => "success",
+                    "message" => "Installation created, but failed to assign CHDM to branch."
+                ];
+            }
+        } else {
             return [
                 "message" => "Failed to create installation.",
                 "status" => "error",
@@ -120,11 +171,10 @@
                 'status'=> 'error'
             ];
         }
-      
-
-        if (!empty($missing)) {
+        
+        if (!$this->checkRoles($user['role_name'], 'view_pending_installations')) {
             return [
-                'message'=> 'Missing required fields: ' . implode(', ', $missing),
+                'message'=> 'Unauthorized: Admin or Technician access required',
                 'status'=> 'error'
             ];
         }
@@ -362,9 +412,77 @@ public function view_all_installations() {
             'status' => 'error'
         ];
     }
-
-
-
 }
+ public function update_all_installations($data) {
+    $user = $this->getAuthenticatedUser();
+    if (!$user) {
+        return [
+            'message' => 'Invalid or expired token. Please log in again.',
+            'status' => 'error'
+        ];
+    }
+    if (!$this->checkRoles($user['role_name'], 'update_all_installations')) {
+        return [
+            'message' => 'Unauthorized: Admin access required',
+            'status' => 'error'
+        ];
+    }
+
+    $missing = $this->validateFields($data, ['installation_id']);
+    if (!empty($missing)) {
+        return [
+            'message' => 'Missing required fields: ' . implode(', ', $missing),
+            'status' => 'error'
+        ];
+    }
+
+    // First, get the existing installation data
+    $installation = new Installation();
+    $allInstallations = $installation->read();
+    $existingInstallation = null;
+    
+    foreach ($allInstallations as $inst) {
+        if ($inst['installation_id'] == $data['installation_id']) {
+            $existingInstallation = $inst;
+            break;
+        }
+    }
+    
+    if (!$existingInstallation) {
+        return [
+            'message' => 'Installation not found',
+            'status' => 'error'
+        ];
+    }
+    
+    // Create installation object with existing data, then override with new data
+    $installation = new Installation(
+        $data['installation_id'],
+        isset($data['chdm_id']) ? $data['chdm_id'] : $existingInstallation['chdm_id'],
+        isset($data['branch_id']) ? $data['branch_id'] : $existingInstallation['branch_id'],
+        isset($data['technician_id']) ? $data['technician_id'] : $existingInstallation['technician_id'],
+        isset($data['status']) ? $data['status'] : $existingInstallation['status'],
+        isset($data['date']) ? $data['date'] : $existingInstallation['date'],
+        isset($data['completion_date']) ? $data['completion_date'] : $existingInstallation['completion_date'],
+        isset($data['software_version']) ? $data['software_version'] : $existingInstallation['software_version'],
+        isset($data['ip_address']) ? $data['ip_address'] : $existingInstallation['ip_address'],
+        isset($data['notes']) ? $data['notes'] : $existingInstallation['notes'],
+        isset($data['serial_no']) ? $data['serial_no'] : (isset($existingInstallation['serial_no']) ? $existingInstallation['serial_no'] : null)
+    );
+    
+    $success = $installation->update_all();
+    
+    if ($success) {
+        return [
+            'status' => 'success',
+            'message' => 'Installation updated successfully'
+        ];
+    } else {
+        return [
+            'status' => 'error',
+            'message' => 'Failed to update installation'
+        ];
+    }
+ }
 }
  

--- a/src/api/Service_Reporting/Service_ReportingApi.php
+++ b/src/api/Service_Reporting/Service_ReportingApi.php
@@ -1,13 +1,15 @@
 <?php
 class Service_ReportingApi extends ApiResourceBase {
-    public function __construct() {
-        $this->setRoles([
-            "create_service_report" => ["Technician", "admin"],
-            "view_service_reports" => ["Technician", "admin"],
-            "update_service_reports" => ["Technician", "admin"],
-            "delete_service_report" => ["Technician", "admin"]
-        ]);
-    }
+public function __construct() {
+    $this->setRoles([
+        "create_service_report" => ["Technician", "admin"],
+        "view_service_reports" => ["Technician", "admin"],
+        "update_service_reports" => ["Technician", "admin"],
+        "delete_service_report" => ["Technician", "admin"],
+        "view_all_service_reports" => ["Technician", "admin"]
+    ]);
+}
+
 public function create_service_report($data) {
     $user = $this->getAuthenticatedUser();
     if(!$user) {
@@ -31,7 +33,7 @@ public function create_service_report($data) {
         'service_date',
         'service_type',
         'service_notes',
-        'created_at'
+        'quarter'
         
     ]);
     if(!empty($missing)) {
@@ -40,6 +42,27 @@ public function create_service_report($data) {
             'message' => 'Missing fields: ' . implode(', ', $missing)
         ];
     }
+    
+    // Validate device_type
+    $validDeviceTypes = ['teller_scanner', 'chdm'];
+    if (!in_array(strtolower($data['device_type']), $validDeviceTypes)) {
+        return [
+            'status' => 'error',
+            'message' => 'Invalid device_type. Allowed values: ' . implode(', ', $validDeviceTypes)
+        ];
+    }
+    
+    // Convert quarter string to integer (Q1->1, Q2->2, Q3->3, Q4->4)
+    $quarter = $data['quarter'];
+    if (is_string($quarter) && preg_match('/^Q([1-4])$/i', $quarter, $matches)) {
+        $quarter = (int)$matches[1];
+    } elseif (!is_numeric($quarter) || $quarter < 1 || $quarter > 4) {
+        return [
+            'status' => 'error',
+            'message' => 'Invalid quarter value. Use Q1, Q2, Q3, Q4 or 1, 2, 3, 4'
+        ];
+    }
+    
     $serviceReport = new Service_Reporting(
         null,
         $data['branch_id'],
@@ -51,7 +74,8 @@ public function create_service_report($data) {
         $data['service_notes'],
         $data['created_at'],
         $data['teller_scanner_serial']?? null,
-        $data['chdm_serial']?? null
+        $data['chdm_serial']?? null,
+        $quarter
         );
     $success = $serviceReport->create();
     if($success) {
@@ -175,4 +199,33 @@ public function update_service_reports($data) {
         ];
  }
 }
+  public function view_all_service_reports($data) {
+        $user = $this->getAuthenticatedUser();
+        if(!$user) {
+            return [
+                "message"=> "Invalid or expired authentication token. Please log in again.",
+                "status"=> "error",
+            ];
+        }
+        if(!$this->checkRoles($user['role_name'], 'view_all_service_reports')) {
+            return [
+                "message" => "Unauthorized access. Admin or Technician access required",
+                "status"=> "error",
+            ];
+        }
+        $service = new Service_Reporting();
+        $results = $service->readAll();
+        if($results) {
+            return [
+                "status" => "success",
+                "message" => "Service reports retrieved successfully",
+                "data" => $results
+            ];
+        } else {
+            return [
+                "message" => "No service reports found",
+                "status" => "error",
+            ];
+        }
+    }
 }

--- a/src/api/branch/branchApi.php
+++ b/src/api/branch/branchApi.php
@@ -50,6 +50,41 @@ class BranchApi extends ApiResourceBase{
             ];
         }
     }
+    public function getByName($data) {
+        $user = $this->getAuthenticatedUser();
+        if(!$user){
+            return [
+                "status" => "error",
+                "message" => "Invalid authentication token"
+            ];
+        }
+        if(!$this->checkRoles($user['role_name'], 'read_branch')){
+            return [
+                "status" => "error",
+                "message" => "Unauthorized: Admin or technician access required"
+            ];
+        }
+        $missing = $this->validateFields($data, ['name']);
+        if(!empty($missing)){
+            return [
+                "status" => "error",
+                "message" => "Invalid Request. Missing fields: " . implode(", ", $missing)
+            ];
+        }
+        $branch = Branch::getByName($data['name']);
+        if ($branch) {
+            return [
+                "status" => "success",
+                "message" => "Branch found.",
+                "data" => $branch
+            ];
+        } else {
+            return [
+                "status" => "error",
+                "message" => "Branch not found."
+            ];
+        }
+    }
 
     public function read_branch($data){
         // Ensure $data is always an array

--- a/src/api/chdm/chdmApi.php
+++ b/src/api/chdm/chdmApi.php
@@ -9,7 +9,10 @@ class ChdmApi extends ApiResourceBase{
         "update_status" => ["admin", "quality_checker"],
         "update_location" => ["admin", "quality_checker"],
         "update_branch_id" => ["admin", "quality_checker"],
-        "delete" => ["admin"]
+        "delete" => ["admin"],
+        "view_all_chdm" => ["admin"],
+        "update_all_chdm" => ["admin"],
+        "get_not_assigned" => ["admin", "quality_checker","technician"]
        ]); 
     }
 
@@ -67,14 +70,14 @@ public function view_passes_chdm($data){
             "status" => "error"
         ];
     }
-    $missing = $this->validateFields($data,["state"]);
+   // $missing = $this->validateFields($data,["state"]);
         
-        if (!empty($missing)) {
-            return [
-                "message" => "Missing required fields: " . implode(", ", $missing),
-                "status" => "error"
-            ];
-        }
+      //  if (!empty($missing)) {
+          //  return [
+           //     "message" => "Missing required fields: " . implode(", ", $missing),
+             //   "status" => "error"
+          //  ];
+      //  }
    $chdm = new Chdm();
    $result = $chdm->read();
    if($result){
@@ -192,7 +195,7 @@ public function update_location($data) {
     }
 
     $chdm = new Chdm($data['serial_no'], null, null, $data['location']);
-    $success = $chdm->update_location($data['location']);
+    $success = $chdm->Update_location($data['location']);
     if ($success) {
         return [
             "status"=> "success",
@@ -229,7 +232,7 @@ public function update_branch_id($data) {
         ];
     }
     $chdm = new Chdm($data["serial_no"], null,$data["branch_id"]);
-    $success = $chdm->update_branch_id($data["branch_id"]);
+    $success = $chdm->Update_branch_id($data["branch_id"]);
     if ($success) {
         return [
             "status"=> "success",
@@ -268,7 +271,7 @@ public function update_branch_id($data) {
                 "status"=> "error"
             ];
         }
-        $chdm = new Chdm($data['serial_no']);
+        $chdm = new Chdm(null, $data['serial_no']);
         $success = $chdm->delete();
         if ($success) {
             return [
@@ -283,6 +286,165 @@ public function update_branch_id($data) {
         }
     }
 
+public function assignForBranch($data) {
+        $user = $this->getAuthenticatedUser();
+        if (!$user) {
+            return [
+                "message"=> "Invalid or expired token. Please log in again.",
+                "status"=> "error"
+            ];
+        }
+
+        if (!$this->checkRoles($user["role_name"], "assign_for_branch")){
+            return [
+                "message"=> "Unauthorized: Admin access required",
+                "status"=> "error"
+            ];
+        }
+
+        $missing = $this->validateFields($data, ["serial_no", "branch_id"]);
+
+        if (!empty($missing)) {
+            return [
+                "message"=> "Missing required fields: " . implode(", ", $missing),
+                "status"=> "error"
+            ];
+        }
+
+        $chdm = new Chdm(null, $data['serial_no'], null, null, null, null, $data['branch_id']);
+        $success = $chdm->assignForBranch();
+        
+        if ($success) {
+            return [
+                "status"=> "success",
+                "message"=> "CHDM assigned to branch successfully"
+            ];
+        } else {
+            return [
+                "message"=> "Failed to assign CHDM to branch",
+                "status"=> "error"
+            ];
+        }
+    }
+
+
+    public function view_all_chdm($data) {
+        $user = $this->getAuthenticatedUser();
+        if (!$user) {
+            return [
+                "message"=> "Invalid or expired token. Please log in again.",
+                "status"=> "error"
+            ];
+        }
+
+        if (!$this->checkRoles($user["role_name"], "view_all_chdm")){
+            return [
+                "message"=> "Unauthorized: Admin access required",
+                "status"=> "error"
+            ];
+        }
+
+        $chdm = new Chdm();
+        $result = $chdm->readAll();
+        if ($result) {
+            return [
+                "status"=> "success",
+                "message"=> "All CHDM records retrieved successfully",
+                "data"=> $result
+            ];
+        } else {
+            return [
+                "message"=> "No CHDM records found",
+                "status"=> "error"
+            ];
+        }
+    }
+    public function get_not_assigned() {
+        $user = $this->getAuthenticatedUser();
+        if (!$user) {
+            return [
+                "message"=> "Invalid or expired token. Please log in again.",
+                "status"=> "error"
+            ];
+        }
+        $chdm = new Chdm();
+        $result = $chdm::getNotAssigned();
+        if ($result) {
+            return [
+                "status"=> "success",
+                "message"=> "CHDM records not assigned to any branch retrieved successfully",
+                "data"=> $result
+            ];
+        } else {
+            return [
+                "message"=> "No CHDM records found",
+                "status"=> "error"
+            ];
+        }
+    }
+
+
+  public function update_all_chdm($data) {
+        $user = $this->getAuthenticatedUser();
+        if (!$user) {
+            return [
+                "message"=> "Invalid or expired token. Please log in again.",
+                "status"=> "error"
+            ];
+        }
+
+        if (!$this->checkRoles($user["role_name"], "update_all_chdm")){
+            return [
+                "message"=> "Unauthorized: Admin access required",
+                "status"=> "error"
+            ];
+        }
+
+        $missing = $this->validateFields($data, ["id"]);
+        if (!empty($missing)) {
+            return [
+                "message"=> "Missing required fields: " . implode(", ", $missing),
+                "status"=> "error"
+            ];
+        }
+
+        $chdm = new Chdm();
+        $allChdm = $chdm->readAll();
+        $existingChdm = null;
+
+        foreach ($allChdm as $inst) {
+            if ($inst['id'] == $data['id']) {
+                $existingChdm = $inst;
+                break;
+            }
+        }
+
+        $chdm = new Chdm(
+            $data['id'],
+            isset($data['serial_no']) ? $data['serial_no'] : $existingChdm['serial_no'],
+            isset($data['state']) ? $data['state'] : $existingChdm['state'],
+            isset($data['location']) ? $data['location'] : $existingChdm['location'],
+            isset($data['description']) ? $data['description'] : $existingChdm['description'],
+            isset($data['tested_date']) ? $data['tested_date'] : $existingChdm['tested_date'],
+            isset($data['branch_id']) ? $data['branch_id'] :$existingChdm['branch_id']
+        );
+        
+        $success = $chdm->update_all();
+        
+        if ($success) {
+            return [
+                "status"=> "success",
+                "message"=> "CHDM record updated successfully"
+            ];
+        } else {
+            return [
+                "message"=> "Failed to update CHDM record",
+                "status"=> "error"
+            ];
+        }
+    }
+
+    
 }
 
 

--- a/src/classes/Branch.php
+++ b/src/classes/Branch.php
@@ -58,6 +58,16 @@ class Branch extends Model{
         
     }
 
+    static public function getByName($name) {
+        $conn = DatabaseConnection::getConnection();
+        $sql = "SELECT branch_id FROM branch WHERE name = :name";
+        $stmt = $conn->prepare($sql);
+        $stmt->bindParam(":name", $name);
+        $stmt->execute();
+        $branch = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $branch;
+    }
+
 
     
     public function update(){

--- a/src/classes/Chdm.php
+++ b/src/classes/Chdm.php
@@ -48,6 +48,16 @@ class Chdm extends Model{
         
         
     }
+    
+    public function readAll() {
+        $conn = DatabaseConnection::getConnection();
+        $sql = "SELECT chdm.*, branch.branch_id AS branch_branch_id, branch.client_id AS branch_client_id, branch.name AS branch_name, branch.address AS branch_address, branch.latitude AS branch_latitude, branch.longitude AS branch_longitude, branch.location AS branch_location, branch.contact_person AS branch_contact_person, branch.phone AS branch_phone, branch.email AS branch_email FROM chdm LEFT JOIN branch ON chdm.branch_id = branch.branch_id ORDER BY chdm.tested_date DESC";
+        $stmt = $conn->prepare($sql);
+        $stmt->execute();
+        $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return $result;
+    }
+    
     public function read_failed() {
         $conn = DatabaseConnection::getConnection();
         $sql = "SELECT * FROM chdm WHERE state = 'failed'";
@@ -99,6 +109,37 @@ class Chdm extends Model{
         $success = $stmt->execute();
         return $success;
     }
+    static public function getNotAssigned() {
+        $conn = DatabaseConnection::getConnection();
+        $sql = "SELECT * FROM chdm WHERE branch_id IS NULL";
+        $stmt = $conn->prepare($sql);
+        $stmt->execute();
+        $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return $result;
+    }
+    static function assignForBranch($serial_no, $branch_id) {
+        $conn = DatabaseConnection::getConnection();
+        $sql = "UPDATE chdm SET branch_id = :branch_id, location = :location WHERE serial_no = :serial_no";
+        $stmt = $conn->prepare($sql);
+        $stmt->bindParam(':branch_id', $branch_id);
+        $stmt->bindParam(':location', $branch_id); // Set location to branch_id
+        $stmt->bindParam(':serial_no', $serial_no);
+        $success = $stmt->execute();
+        return $success;
+    }
 
-    
+    public function update_all() {
+        $conn = DatabaseConnection::getConnection();
+        $sql = "UPDATE chdm SET serial_no = :serial_no, state = :state, location = :location, description = :description, tested_date = :tested_date, branch_id = :branch_id WHERE id = :id";
+        $stmt = $conn->prepare($sql);
+        $stmt->bindParam(':serial_no', $this->serial_no);
+        $stmt->bindParam(':state', $this->state);
+        $stmt->bindParam(':location', $this->location);
+        $stmt->bindParam(':description', $this->description);
+        $stmt->bindParam(':tested_date', $this->tested_date);
+        $stmt->bindParam(':branch_id', $this->branch_id);
+        $stmt->bindParam(':id', $this->id);
+        $success = $stmt->execute();
+        return $success;
+    }
 }

--- a/src/classes/Installation.php
+++ b/src/classes/Installation.php
@@ -10,8 +10,10 @@
         public $software_version;
         public $ip_address;
         public $notes;
+        
+        public $serial_no;
 
-        public function __construct($installation_id = null, $chdm_id = null, $branch_id = null, $technician_id = null, $status = null, $date = null, $completion_date = null, $software_version = null, $ip_address = null, $notes = null){
+        public function __construct($installation_id = null, $chdm_id = null, $branch_id = null, $technician_id = null, $status = null, $date = null, $completion_date = null, $software_version = null, $ip_address = null, $notes = null, $serial_no = null){
             $this->installation_id = $installation_id;
             $this->chdm_id = $chdm_id;
             $this->branch_id = $branch_id;
@@ -22,12 +24,13 @@
             $this->software_version = $software_version;
             $this->ip_address = $ip_address;
             $this->notes = $notes;
+            $this->serial_no = $serial_no;
         }
 
         public function create(){
             $conn = DatabaseConnection::getConnection();
-            $sql = "INSERT INTO installation (chdm_id, branch_id, technician_id, status, date, software_version, ip_address, notes)
-                    VALUES (:chdm_id, :branch_id, :technician_id, :status, :date, :software_version, :ip_address, :notes)";
+            $sql = "INSERT INTO installation (chdm_id, branch_id, technician_id, status, date, software_version, ip_address, notes, serial_no)
+                    VALUES (:chdm_id, :branch_id, :technician_id, :status, :date, :software_version, :ip_address, :notes, :serial_no)";
             $stmt = $conn->prepare($sql);
 
             $stmt->bindParam(":chdm_id", $this->chdm_id);
@@ -38,6 +41,7 @@
             $stmt->bindParam(":software_version", $this->software_version);
             $stmt->bindParam(":ip_address", $this->ip_address);
             $stmt->bindParam(":notes", $this->notes);
+            $stmt->bindParam(":serial_no", $this->serial_no);
 
             $success = $stmt->execute();
             return $success;
@@ -55,6 +59,7 @@
                         i.software_version,
                         i.ip_address,
                         i.notes,
+                        i.serial_no,
                         u.username as technician_name,
                         u.email as technician_email,
                         u.phone as technician_phone
@@ -80,6 +85,7 @@
                         i.software_version,
                         i.ip_address,
                         i.notes,
+                        i.serial_no,
                         u.username as technician_name,
                         u.email as technician_email,
                         u.phone as technician_phone
@@ -104,6 +110,7 @@
                         i.software_version,
                         i.ip_address,
                         i.notes,
+                        i.serial_no,
                         u.username as technician_name,
                         u.email as technician_email,
                         u.phone as technician_phone
@@ -115,7 +122,6 @@
             $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
             return $result;
 
-            
         }
          public function update_status($status) {
             $conn = DatabaseConnection::getConnection();
@@ -169,5 +175,22 @@
             $success = $stmt->execute();
             return $success;
         }
-
+      public function update_all() {
+        $conn = DatabaseConnection::getConnection();
+        $sql = "UPDATE installation SET chdm_id = :chdm_id, branch_id = :branch_id, technician_id = :technician_id, status = :status, date = :date, completion_date = :completion_date, software_version = :software_version, ip_address = :ip_address, notes = :notes, serial_no = :serial_no WHERE installation_id = :installation_id";
+        $stmt = $conn->prepare($sql);
+        $stmt->bindParam(":chdm_id", $this->chdm_id);
+        $stmt->bindParam(":branch_id", $this->branch_id);
+        $stmt->bindParam(":technician_id", $this->technician_id);
+        $stmt->bindParam(":status", $this->status);
+        $stmt->bindParam(":date", $this->date);
+        $stmt->bindParam(":completion_date", $this->completion_date);
+        $stmt->bindParam(":software_version", $this->software_version);
+        $stmt->bindParam(":ip_address", $this->ip_address);
+        $stmt->bindParam(":notes", $this->notes);
+        $stmt->bindParam(":serial_no", $this->serial_no);
+        $stmt->bindParam(":installation_id", $this->installation_id);
+        $success = $stmt->execute();
+        return $success;
+      }
     }

--- a/src/classes/service.php
+++ b/src/classes/service.php
@@ -11,8 +11,9 @@
     public $created_at;
     public $teller_scanner_serial;
     public $chdm_serial;
+    public $quarter;
 
-    public function __construct($service_id = null, $branch_id = null, $client_id = null, $user_id = null, $device_type = null, $service_date = null, $service_type = null, $service_notes = null, $created_at = null, $teller_scanner_serial = null, $chdm_serial = null) {
+    public function __construct($service_id = null, $branch_id = null, $client_id = null, $user_id = null, $device_type = null, $service_date = null, $service_type = null, $service_notes = null, $created_at = null, $teller_scanner_serial = null, $chdm_serial = null, $quarter = null) {
         $this->service_id = $service_id;
         $this->branch_id = $branch_id;
         $this->client_id = $client_id;
@@ -24,12 +25,13 @@
         $this->created_at = $created_at;
         $this->teller_scanner_serial = $teller_scanner_serial;
         $this->chdm_serial = $chdm_serial;
+        $this->quarter = $quarter;
     }
 
     public function create() {
         $conn = DatabaseConnection::getConnection();
-        $sql = "INSERT INTO service (branch_id, client_id, user_id, device_type, service_date, service_type, service_notes, created_at, teller_scanner_serial, chdm_serial)
-                VALUES (:branch_id, :client_id, :user_id, :device_type, :service_date, :service_type, :service_notes, :created_at, :teller_scanner_serial, :chdm_serial)";
+        $sql = "INSERT INTO service (branch_id, client_id, user_id, device_type, service_date, service_type, service_notes, created_at, teller_scanner_serial, chdm_serial, quarter)
+                VALUES (:branch_id, :client_id, :user_id, :device_type, :service_date, :service_type, :service_notes, :created_at, :teller_scanner_serial, :chdm_serial, :quarter)";
         $stmt = $conn->prepare($sql);
 
         $stmt->bindParam(":branch_id", $this->branch_id);
@@ -42,6 +44,7 @@
         $stmt->bindParam(":created_at", $this->created_at);
         $stmt->bindParam(":teller_scanner_serial", $this->teller_scanner_serial);
         $stmt->bindParam(":chdm_serial", $this->chdm_serial);
+        $stmt->bindParam(":quarter", $this->quarter);
 
         $success = $stmt->execute();
         return $success;
@@ -58,7 +61,8 @@
     service_notes LIKE :keyword OR
     CAST(created_at AS TEXT) LIKE :keyword OR
     teller_scanner_serial LIKE :keyword OR
-    chdm_serial LIKE :keyword";
+    chdm_serial LIKE :keyword OR
+    CAST(quarter AS TEXT) LIKE :keyword";
 
         $stmt = $conn->prepare($sql);
         $likeKeyword = '%' . $keyword . '%';
@@ -69,6 +73,7 @@
     }
 
     public function read(){}
+
    
     public function update_service_fields( $data) {
         if (!isset($this->service_id)) {
@@ -102,6 +107,10 @@
             $fields[] = 'chdm_serial = :chdm_serial';
             $params[':chdm_serial'] = $data['chdm_serial'];
         }
+        if(isset($data['quarter'])) {
+            $fields[] = 'quarter = :quarter';
+            $params[':quarter'] = $data['quarter'];
+        }
 
         if(empty($fields)) {
             return false; // No fields to update
@@ -129,5 +138,14 @@
     }
     public function update(){}
     
+    public function readAll() {
+        $conn = DatabaseConnection::getConnection();
+        $sql = "SELECT * FROM service ORDER BY created_at DESC";
+        $stmt = $conn->prepare($sql);
+        $stmt->execute();
+        $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return $result;
+        
+    }
 
 }


### PR DESCRIPTION
Introduces new API endpoints and supporting methods for admins to update and retrieve all installations, CHDMs, and service reports. Adds serial_no and quarter fields to relevant models and database operations. Implements assignment of CHDMs to branches and retrieval of unassigned CHDMs. Also adds branch lookup by name and improves validation and role checks across APIs.