### PR TITLE
Himali

### DIFF
--- a/src/api/chdm/chdmApi.php
+++ b/src/api/chdm/chdmApi.php
@@ -10,8 +10,8 @@ class ChdmApi extends ApiResourceBase{
         "update_location" => ["admin", "quality_checker"],
         "update_branch_id" => ["admin", "quality_checker"],
         "delete" => ["admin"],
-        "view_all_chdm" => ["admin"],
-        "update_all_chdm" => ["admin"],
+        "view_all_chdm" => ["admin", "quality_checker"],
+        "update_all_chdm" => ["admin", "quality_checker"],
         "get_not_assigned" => ["admin", "quality_checker","technician"]
        ]); 
     }
@@ -271,6 +271,21 @@ public function update_branch_id($data) {
                 "status"=> "error"
             ];
         }
+    
+          // Check if CHDM is assigned in installation table
+         $conn = DatabaseConnection::getConnection();
+         $checkSql = "SELECT * FROM installation WHERE chdm_id = (SELECT id FROM chdm WHERE serial_no = :serial_no)";
+         $stmt = $conn->prepare($checkSql);
+         $stmt->bindParam(':serial_no', $data['serial_no']);
+         $stmt->execute();
+
+       if ($stmt->rowCount() > 0) {
+          return [
+            "message"=> "Cannot delete CHDM. It is already assigned to an installation.",
+            "status"=> "error"
+        ];
+    }
+
         $chdm = new Chdm(null, $data['serial_no']);
         $success = $chdm->delete();
         if ($success) {
@@ -339,7 +354,7 @@ public function assignForBranch($data) {
 
         if (!$this->checkRoles($user["role_name"], "view_all_chdm")){
             return [
-                "message"=> "Unauthorized: Admin access required",
+                "message"=> "Unauthorized: Admin & Quality Checker access required",
                 "status"=> "error"
             ];
         }
@@ -395,7 +410,7 @@ public function assignForBranch($data) {
 
         if (!$this->checkRoles($user["role_name"], "update_all_chdm")){
             return [
-                "message"=> "Unauthorized: Admin access required",
+                "message"=> "Unauthorized: Admin & Quality Checker access required",
                 "status"=> "error"
             ];
         }
@@ -407,6 +422,20 @@ public function assignForBranch($data) {
                 "status"=> "error"
             ];
         }
+
+         // Check if this CHDM is already assigned
+    $conn = DatabaseConnection::getConnection();
+    $checkSql = "SELECT * FROM installation WHERE chdm_id = :chdm_id";
+    $stmt = $conn->prepare($checkSql);
+    $stmt->bindParam(":chdm_id", $data['id']);
+    $stmt->execute();
+
+    if ($stmt->rowCount() > 0) {
+        return [
+            "message" => "Cannot update CHDM. It is already assigned to an installation.",
+            "status" => "error"
+        ];
+    }
 
         $chdm = new Chdm();
         $allChdm = $chdm->readAll();

--- a/src/classes/Branch.php
+++ b/src/classes/Branch.php
@@ -185,15 +185,15 @@ class Branch extends Model{
         return $branch;
     }
 
-    public static function getByName($name) {
-        $conn = DatabaseConnection::getConnection();
-        $sql = "SELECT * FROM branch WHERE name = :name";
-        $stmt = $conn->prepare($sql);
-        $stmt->bindParam(":name", $name);
-        $stmt->execute();
-        $branch = $stmt->fetch(PDO::FETCH_ASSOC);
-        return $branch;
-    }
+    // public static function getByName($name) {
+    //     $conn = DatabaseConnection::getConnection();
+    //     $sql = "SELECT * FROM branch WHERE name = :name";
+    //     $stmt = $conn->prepare($sql);
+    //     $stmt->bindParam(":name", $name);
+    //     $stmt->execute();
+    //     $branch = $stmt->fetch(PDO::FETCH_ASSOC);
+    //     return $branch;
+    // }
 
 
 

--- a/src/classes/Chdm.php
+++ b/src/classes/Chdm.php
@@ -111,7 +111,7 @@ class Chdm extends Model{
     }
     static public function getNotAssigned() {
         $conn = DatabaseConnection::getConnection();
-        $sql = "SELECT * FROM chdm WHERE branch_id IS NULL";
+        $sql = "SELECT * FROM chdm WHERE branch_id IS NULL AND state = 'passed'";
         $stmt = $conn->prepare($sql);
         $stmt->execute();
         $result = $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
This pull request introduces several updates to the `CHDM` API and related classes, focusing on role-based access control, validation for CHDM assignments, and minor code cleanup. The most important changes include extending permissions for `view_all_chdm` and `update_all_chdm` actions, adding checks to prevent operations on assigned CHDMs, and modifying the `getNotAssigned` query to include a state filter.

### Role-based access control updates:
* Extended access for `view_all_chdm` and `update_all_chdm` to include "Quality Checker" in addition to "Admin" (`src/api/chdm/chdmApi.php`). [[1]](diffhunk://#diff-bfa2670344c9f409774b75e6f16dd0238fae1f7283aa7b2a089f8b29b09c1c88L13-R14) [[2]](diffhunk://#diff-bfa2670344c9f409774b75e6f16dd0238fae1f7283aa7b2a089f8b29b09c1c88L342-R357) [[3]](diffhunk://#diff-bfa2670344c9f409774b75e6f16dd0238fae1f7283aa7b2a089f8b29b09c1c88L398-R413)

### Validation for CHDM assignments:
* Added a check in `delete` to prevent deletion of CHDMs that are assigned to an installation (`src/api/chdm/chdmApi.php`).
* Added a check in `update_all_chdm` to prevent updates to CHDMs that are already assigned to an installation (`src/api/chdm/chdmApi.php`).

### Query updates:
* Updated the `getNotAssigned` query in `Chdm` class to filter results by `state = 'passed'` (`src/classes/Chdm.php`).

### Code cleanup:
* Commented out the unused `getByName` method in the `Branch` class (`src/classes/Branch.php`).