### PR TITLE
Prod

### DIFF
--- a/src/api/chdm/chdmApi.php
+++ b/src/api/chdm/chdmApi.php
@@ -456,8 +456,7 @@ public function assignForBranch($data) {
             isset($data['state']) ? $data['state'] : $existingChdm['state'],
             isset($data['location']) ? $data['location'] : $existingChdm['location'],
             isset($data['description']) ? $data['description'] : $existingChdm['description'],
-            isset($data['tested_date']) ? $data['tested_date'] : $existingChdm['tested_date'],
-            isset($data['branch_id']) ? $data['branch_id'] :$existingChdm['branch_id']
+            isset($data['tested_date']) ? $data['tested_date'] : $existingChdm['tested_date']
         );
         
         $success = $chdm->update_all();

--- a/src/classes/Chdm.php
+++ b/src/classes/Chdm.php
@@ -130,14 +130,13 @@ class Chdm extends Model{
 
     public function update_all() {
         $conn = DatabaseConnection::getConnection();
-        $sql = "UPDATE chdm SET serial_no = :serial_no, state = :state, location = :location, description = :description, tested_date = :tested_date, branch_id = :branch_id WHERE id = :id";
+        $sql = "UPDATE chdm SET serial_no = :serial_no, state = :state, location = :location, description = :description, tested_date = :tested_date WHERE id = :id";
         $stmt = $conn->prepare($sql);
         $stmt->bindParam(':serial_no', $this->serial_no);
         $stmt->bindParam(':state', $this->state);
         $stmt->bindParam(':location', $this->location);
         $stmt->bindParam(':description', $this->description);
         $stmt->bindParam(':tested_date', $this->tested_date);
-        $stmt->bindParam(':branch_id', $this->branch_id);
         $stmt->bindParam(':id', $this->id);
         $success = $stmt->execute();
         return $success;


### PR DESCRIPTION
This pull request modifies the handling of the `branch_id` field in the CHDM update functionality, removing it from the update operations in both the API and database layers. The changes simplify the code by eliminating unnecessary references to `branch_id`.

### Removal of `branch_id` from CHDM update functionality:

* [`src/api/chdm/chdmApi.php`](diffhunk://#diff-bfa2670344c9f409774b75e6f16dd0238fae1f7283aa7b2a089f8b29b09c1c88L505-R505): Removed the inclusion of `branch_id` in the data array passed to the `update_all` method in the `update_all_chdm` function. (`[src/api/chdm/chdmApi.phpL505-R505](diffhunk://#diff-bfa2670344c9f409774b75e6f16dd0238fae1f7283aa7b2a089f8b29b09c1c88L505-R505)`)
* [`src/classes/Chdm.php`](diffhunk://#diff-26d2318f61eb17a8cee851106a34da06ef9387e59484705aa56d306a19871d3eL148-L155): Updated the SQL query in the `update_all` method to exclude the `branch_id` field, and removed the corresponding `bindParam` call. (`[src/classes/Chdm.phpL148-L155](diffhunk://#diff-26d2318f61eb17a8cee851106a34da06ef9387e59484705aa56d306a19871d3eL148-L155)`)