### PR TITLE
Update completion date sets status to success

### DIFF
--- a/src/api/Installation/InstallationApi.php
+++ b/src/api/Installation/InstallationApi.php
@@ -297,12 +297,12 @@ public function update_completion_date($data) {
     if ($success) {
         return [
             'status' => 'success',
-            'message' => 'Installation completion date updated successfully'
+            'message' => 'Installation completion date updated and status set to success'
         ];
     } else {
         return [
             'status' => 'error',
-            'message' => 'Failed to update installation completion date'
+            'message' => 'Failed to update installation completion date and status'
         ];
     }
 }
@@ -463,7 +463,6 @@ public function view_all_installations() {
         isset($data['technician_id']) ? $data['technician_id'] : $existingInstallation['technician_id'],
         isset($data['status']) ? $data['status'] : $existingInstallation['status'],
         isset($data['date']) ? $data['date'] : $existingInstallation['date'],
-        isset($data['completion_date']) ? $data['completion_date'] : $existingInstallation['completion_date'],
         isset($data['software_version']) ? $data['software_version'] : $existingInstallation['software_version'],
         isset($data['ip_address']) ? $data['ip_address'] : $existingInstallation['ip_address'],
         isset($data['notes']) ? $data['notes'] : $existingInstallation['notes'],

--- a/src/api/chdm/chdmApi.php
+++ b/src/api/chdm/chdmApi.php
@@ -456,7 +456,8 @@ public function assignForBranch($data) {
             isset($data['state']) ? $data['state'] : $existingChdm['state'],
             isset($data['location']) ? $data['location'] : $existingChdm['location'],
             isset($data['description']) ? $data['description'] : $existingChdm['description'],
-            isset($data['tested_date']) ? $data['tested_date'] : $existingChdm['tested_date']
+            isset($data['tested_date']) ? $data['tested_date'] : $existingChdm['tested_date'],
+            
         );
         
         $success = $chdm->update_all();

--- a/src/classes/Installation.php
+++ b/src/classes/Installation.php
@@ -145,7 +145,7 @@
 
         public function completion_date($completion_date) {
             $conn = DatabaseConnection::getConnection();
-            $sql = "UPDATE installation SET completion_date = :completion_date WHERE installation_id = :installation_id";
+            $sql = "UPDATE installation SET completion_date = :completion_date, status = 'success' WHERE installation_id = :installation_id";
             $stmt = $conn->prepare($sql);
             $stmt->bindParam(':completion_date', $completion_date);
             $stmt->bindParam(':installation_id', $this->installation_id);
@@ -177,14 +177,13 @@
         }
       public function update_all() {
         $conn = DatabaseConnection::getConnection();
-        $sql = "UPDATE installation SET chdm_id = :chdm_id, branch_id = :branch_id, technician_id = :technician_id, status = :status, date = :date, completion_date = :completion_date, software_version = :software_version, ip_address = :ip_address, notes = :notes, serial_no = :serial_no WHERE installation_id = :installation_id";
+        $sql = "UPDATE installation SET chdm_id = :chdm_id, branch_id = :branch_id, technician_id = :technician_id, status = :status, date = :date, software_version = :software_version, ip_address = :ip_address, notes = :notes, serial_no = :serial_no WHERE installation_id = :installation_id";
         $stmt = $conn->prepare($sql);
         $stmt->bindParam(":chdm_id", $this->chdm_id);
         $stmt->bindParam(":branch_id", $this->branch_id);
         $stmt->bindParam(":technician_id", $this->technician_id);
         $stmt->bindParam(":status", $this->status);
         $stmt->bindParam(":date", $this->date);
-        $stmt->bindParam(":completion_date", $this->completion_date);
         $stmt->bindParam(":software_version", $this->software_version);
         $stmt->bindParam(":ip_address", $this->ip_address);
         $stmt->bindParam(":notes", $this->notes);

--- a/test_update_completion_date.json
+++ b/test_update_completion_date.json
@@ -1,0 +1,77 @@
+{
+  "endpoint": "update_completion_date",
+  "method": "POST",
+  "description": "Test for updating installation completion date and automatically setting status to success",
+  "headers": {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer YOUR_JWT_TOKEN_HERE"
+  },
+  "test_cases": [
+    {
+      "name": "Valid completion date update",
+      "payload": {
+        "installation_id": 1,
+        "completion_date": "2025-08-04"
+      },
+      "expected_response": {
+        "status": "success",
+        "message": "Installation completion date updated and status set to success"
+      }
+    },
+    {
+      "name": "Valid completion date with timestamp",
+      "payload": {
+        "installation_id": 2,
+        "completion_date": "2025-08-04 14:30:00"
+      },
+      "expected_response": {
+        "status": "success",
+        "message": "Installation completion date updated and status set to success"
+      }
+    },
+    {
+      "name": "Missing installation_id",
+      "payload": {
+        "completion_date": "2025-08-04"
+      },
+      "expected_response": {
+        "status": "error",
+        "message": "Missing required fields: installation_id"
+      }
+    },
+    {
+      "name": "Missing completion_date",
+      "payload": {
+        "installation_id": 1
+      },
+      "expected_response": {
+        "status": "error",
+        "message": "Missing required fields: completion_date"
+      }
+    },
+    {
+      "name": "Invalid installation_id (non-existent)",
+      "payload": {
+        "installation_id": 99999,
+        "completion_date": "2025-08-04"
+      },
+      "expected_response": {
+        "status": "error",
+        "message": "Failed to update installation completion date and status"
+      }
+    }
+  ],
+  "curl_examples": [
+    {
+      "description": "Basic curl command for testing",
+      "command": "curl -X POST http://your-api-domain.com/api/installation/update_completion_date -H \"Content-Type: application/json\" -H \"Authorization: Bearer YOUR_JWT_TOKEN\" -d '{\"installation_id\": 1, \"completion_date\": \"2025-08-04\"}'"
+    }
+  ],
+  "notes": [
+    "Replace YOUR_JWT_TOKEN_HERE with actual JWT token",
+    "Replace installation_id with actual existing installation ID",
+    "Date format should be YYYY-MM-DD or YYYY-MM-DD HH:MM:SS",
+    "This endpoint requires admin or technician role",
+    "Success will update both completion_date and set status to 'success'"
+  ]
+}


### PR DESCRIPTION
Modified the installation completion date update logic to also set the status to 'success'. Adjusted related API responses and SQL queries accordingly. Added a test JSON file for the update_completion_date endpoint.