### PR TITLE
Add API to view QC reports by user with pagination

### DIFF
--- a/src/api/Qc_Reporting/Qc_ReportingApi.php
+++ b/src/api/Qc_Reporting/Qc_ReportingApi.php
@@ -9,7 +9,8 @@ class Qc_ReportingApi extends ApiResourceBase {
             "update_test_details"=> ["Quality_Checker","admin"],
             "update_report"=> ["Quality_Checker","admin"],
             "delete_report"=> ["admin"],
-            "read"=> ["Quality_Checker","admin"]
+            "read"=> ["Quality_Checker","admin"],
+            "view_my_reports"=> ["Quality_Checker","admin"]
         ]); 
     }
 
@@ -421,6 +422,96 @@ public function read() {
         return [
             "status" => "error",
             "message" => "No quality check reports found or no data available"
+        ];
+    }
+}
+
+public function view_my_reports($data = null) {
+    $user = $this->getAuthenticatedUser();
+    if(!$user){
+        return [
+            "status" => "error",
+            "message" => "Invalid or expired token. Please log in again."
+        ];
+    }
+    
+    // Check role permissions
+    if(!$this->checkRoles($user['role_name'], 'view_my_reports')){
+        return [
+            "status" => "error",
+            "message" => "Unauthorized: Quality Checker or Admin access required"
+        ];
+    }
+    
+    // Get user ID from token
+    $user_id = null;
+    if (isset($user['user_id'])) {
+        $user_id = $user['user_id'];
+    } elseif (isset($user['id'])) {
+        $user_id = $user['id'];
+    } elseif (isset($user['uid'])) {
+        $user_id = $user['uid'];
+    } else {
+        return [
+            'status' => 'error',
+            'message' => 'Unable to determine user ID from authentication token'
+        ];
+    }
+    
+    // Get pagination parameters with defaults
+    $page = isset($data['page']) ? max(1, intval($data['page'])) : 1;
+    $limit = isset($data['limit']) ? max(1, min(100, intval($data['limit']))) : 10;
+    
+    // Get reports for this user with pagination
+    $result = Qc_Reporting::getReportsByUserPaginated($user_id, $page, $limit);
+    
+    if($result['data'] && count($result['data']) > 0){
+        return [
+            "status" => "success",
+            "message" => "Your QC reports retrieved successfully",
+            "data" => $result['data'],
+            "count" => count($result['data']),
+            "total" => $result['total'],
+            "page" => $result['page'],
+            "limit" => $result['limit'],
+            "total_pages" => $result['total_pages'],
+            "user_info" => [
+                "user_id" => $user_id,
+                "username" => isset($user['username']) ? $user['username'] : 'Unknown',
+                "role" => $user['role_name']
+            ],
+            "pagination" => [
+                "current_page" => $result['page'],
+                "per_page" => $result['limit'],
+                "total" => $result['total'],
+                "total_pages" => $result['total_pages'],
+                "has_next" => $result['page'] < $result['total_pages'],
+                "has_prev" => $result['page'] > 1
+            ]
+        ];
+    } else {
+        return [
+            "status" => "success",
+            "message" => "No QC reports found for your account",
+            "data" => [],
+            "count" => 0,
+            "total" => $result['total'],
+            "page" => $result['page'],
+            "limit" => $result['limit'],
+            "total_pages" => $result['total_pages'],
+            "user_info" => [
+                "user_id" => $user_id,
+                "username" => isset($user['username']) ? $user['username'] : 'Unknown',
+                "role" => $user['role_name']
+            ],
+            "pagination" => [
+                "current_page" => $result['page'],
+                "per_page" => $result['limit'],
+                "total" => $result['total'],
+                "total_pages" => $result['total_pages'],
+                "has_next" => false,
+                "has_prev" => false
+            ]
         ];
     }
 }

--- a/src/classes/Qc_Reporting.php
+++ b/src/classes/Qc_Reporting.php
@@ -135,4 +135,70 @@ class Qc_Reporting extends Model {
     $success = $stmt->execute();
     return $success;
   }
+
+  // Get QC reports created by a specific user
+  public static function getReportsByUser($qc_officer_id) {
+    $conn = DatabaseConnection::getConnection();
+    $sql = "SELECT qc.*, 
+                   c.serial_no, 
+                   c.location, 
+                   c.description as chdm_description,
+                   u.username as qc_officer_name,
+                   u.email as qc_officer_email
+            FROM quality_check qc
+            LEFT JOIN chdm c ON qc.chdm_id = c.id
+            LEFT JOIN users u ON qc.qc_officer_id = u.user_id
+            WHERE qc.qc_officer_id = :qc_officer_id
+            ORDER BY qc.date DESC";
+    $stmt = $conn->prepare($sql);
+    $stmt->bindParam(':qc_officer_id', $qc_officer_id);
+    $stmt->execute();
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+  }
+
+  // Get QC reports created by a specific user with pagination
+  public static function getReportsByUserPaginated($qc_officer_id, $page = 1, $limit = 10) {
+    $conn = DatabaseConnection::getConnection();
+    
+    // Calculate offset
+    $offset = ($page - 1) * $limit;
+    
+    // Get total count
+    $countSql = "SELECT COUNT(*) as total 
+                 FROM quality_check qc 
+                 WHERE qc.qc_officer_id = :qc_officer_id";
+    $countStmt = $conn->prepare($countSql);
+    $countStmt->bindParam(':qc_officer_id', $qc_officer_id);
+    $countStmt->execute();
+    $totalCount = $countStmt->fetch(PDO::FETCH_ASSOC)['total'];
+    
+    // Get paginated results
+    $sql = "SELECT qc.*, 
+                   c.serial_no, 
+                   c.location, 
+                   c.description as chdm_description,
+                   u.username as qc_officer_name,
+                   u.email as qc_officer_email
+            FROM quality_check qc
+            LEFT JOIN chdm c ON qc.chdm_id = c.id
+            LEFT JOIN users u ON qc.qc_officer_id = u.user_id
+            WHERE qc.qc_officer_id = :qc_officer_id
+            ORDER BY qc.date DESC, qc.qc_id DESC
+            LIMIT :limit OFFSET :offset";
+    
+    $stmt = $conn->prepare($sql);
+    $stmt->bindParam(':qc_officer_id', $qc_officer_id);
+    $stmt->bindParam(':limit', $limit, PDO::PARAM_INT);
+    $stmt->bindParam(':offset', $offset, PDO::PARAM_INT);
+    $stmt->execute();
+    $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    
+    return [
+      'data' => $results,
+      'total' => $totalCount,
+      'page' => $page,
+      'limit' => $limit,
+      'total_pages' => ceil($totalCount / $limit)
+    ];
+  }
 }


### PR DESCRIPTION
Introduces the 'view_my_reports' endpoint to Qc_ReportingApi, allowing authenticated users to retrieve their own QC reports with pagination. Adds supporting methods in Qc_Reporting for fetching user-specific reports and paginated results, including user and pagination metadata in the response.