### PR TITLE
Add QC dashboard and user dispatch API endpoints

### DIFF
--- a/src/api/Dispatch/dispatchApi.php
+++ b/src/api/Dispatch/dispatchApi.php
@@ -6,7 +6,8 @@ class dispatchApi extends ApiResourceBase {
             "read_dispatch" => ["admin", "Quality_Checker", "user"],
             "update_dispatch" => ["admin", "Quality_Checker"],
             "delete_dispatch" => ["admin"],
-            "readAll" => ["admin", "Quality_Checker", ]
+            "readAll" => ["admin", "Quality_Checker"],
+            "view_my_dispatches" => ["admin", "Quality_Checker", "user"]
         ]);
     }
 
@@ -325,6 +326,98 @@ class dispatchApi extends ApiResourceBase {
             ];
         } else {
             return ['status' => 'error', 'message' => 'Failed to retrieve dispatches or none found.'];
+        }
+    }
+
+    public function view_my_dispatches($data = null) {
+        $user = $this->getAuthenticatedUser();
+        if(!$user){
+            return [
+                "status" => "error",
+                "message" => "Invalid or expired token. Please log in again."
+            ];
+        }
+        
+        // Check role permissions
+        if(!$this->checkRoles($user['role_name'], 'view_my_dispatches')){
+            return [
+                "status" => "error",
+                "message" => "Unauthorized: Admin, Quality Checker, or User access required"
+            ];
+        }
+        
+        // Get user ID from token
+        $user_id = null;
+        if (isset($user['user_id'])) {
+            $user_id = $user['user_id'];
+        } elseif (isset($user['id'])) {
+            $user_id = $user['id'];
+        } elseif (isset($user['uid'])) {
+            $user_id = $user['uid'];
+        } else {
+            return [
+                'status' => 'error',
+                'message' => 'Unable to determine user ID from authentication token'
+            ];
+        }
+        
+        // Get pagination parameters with defaults
+        $page = isset($data['page']) ? max(1, intval($data['page'])) : 1;
+        $limit = isset($data['limit']) ? max(1, min(100, intval($data['limit']))) : 10;
+        
+        // Get dispatches for this user with pagination
+        $result = dispatch::getDispatchesByUserPaginated($user_id, $page, $limit);
+        
+        if($result['data'] && count($result['data']) > 0){
+            return [
+                "status" => "success",
+                "message" => "Your dispatches retrieved successfully",
+                "data" => $result['data'],
+                "count" => count($result['data']),
+                "total" => $result['total'],
+                "page" => $result['page'],
+                "limit" => $result['limit'],
+                "total_pages" => $result['total_pages'],
+                "user_id" => $user_id,
+                "user_info" => [
+                    "user_id" => $user_id,
+                    "username" => isset($user['username']) ? $user['username'] : 'Unknown',
+                    "role" => $user['role_name']
+                ],
+                "pagination" => [
+                    "current_page" => $result['page'],
+                    "per_page" => $result['limit'],
+                    "total" => $result['total'],
+                    "total_pages" => $result['total_pages'],
+                    "has_next" => $result['page'] < $result['total_pages'],
+                    "has_prev" => $result['page'] > 1
+                ]
+            ];
+        } else {
+            return [
+                "status" => "success",
+                "message" => "No dispatches found for your account",
+                "data" => [],
+                "count" => 0,
+                "total" => $result['total'],
+                "page" => $result['page'],
+                "limit" => $result['limit'],
+                "total_pages" => $result['total_pages'],
+                "user_id" => $user_id,
+                "user_info" => [
+                    "user_id" => $user_id,
+                    "username" => isset($user['username']) ? $user['username'] : 'Unknown',
+                    "role" => $user['role_name']
+                ],
+                "pagination" => [
+                    "current_page" => $result['page'],
+                    "per_page" => $result['limit'],
+                    "total" => $result['total'],
+                    "total_pages" => $result['total_pages'],
+                    "has_next" => false,
+                    "has_prev" => false
+                ]
+            ];
         }
     }
 }

--- a/src/api/stats/statsApi.php
+++ b/src/api/stats/statsApi.php
@@ -21,9 +21,184 @@ class StatsApi extends ApiResourceBase {
             'qc_summary' => ['admin','technician'],
             'repair_summary' => ['admin','technician'],
             'inventory_stock_summary' => ['admin','technician'],
-            'technician_dashboard' => ['admin','technician']
+            'technician_dashboard' => ['admin','technician'],
+            'qc_dashboard' => ['admin','Quality_Checker','technician']
         ]);
     }
+
+    /**
+     * GET /api/stats/stats/qc_dashboard
+     * Returns QC dashboard data for the authenticated user
+     * Includes last 5 QC reports, passed/failed CHDM records, and last 5 dispatch records
+     * All data filtered by the authenticated user's created records
+     */
+    public function qc_dashboard($data) {
+        $user = $this->getAuthenticatedUser();
+        if(!$user) {
+            return [
+                "status" => "error",
+                "message" => "Invalid authentication token"
+            ];
+        }
+        
+        $roleName = isset($user['role_name']) ? $user['role_name'] : (isset($user['role']['role_name']) ? $user['role']['role_name'] : null);
+        if(!$this->checkRoles($roleName, 'qc_dashboard')) {
+            return [
+                "status" => "error",
+                "message" => "Unauthorized: Quality Checker, Admin or Technician access required"
+            ];
+        }
+        
+        // Get user ID from token
+        $user_id = null;
+        if (isset($user['user_id'])) {
+            $user_id = $user['user_id'];
+        } elseif (isset($user['id'])) {
+            $user_id = $user['id'];
+        } elseif (isset($user['uid'])) {
+            $user_id = $user['uid'];
+        }
+
+        if (!$user_id) {
+            return [
+                "status" => "error",
+                "message" => "User ID not found in authentication token"
+            ];
+        }
+
+        $conn = DatabaseConnection::getConnection();
+        
+        try {
+            // 1. Last 5 QC reports created by the authenticated user (most recently updated)
+            $qcReportsStmt = $conn->prepare("
+                SELECT qc.qc_id, qc.chdm_id, qc.date, qc.result, qc.remarks, qc.test_details,
+                       c.serial_no, c.location, c.description as chdm_description, c.state as chdm_state,
+                       u.username as qc_officer_name
+                FROM quality_check qc
+                LEFT JOIN chdm c ON qc.chdm_id = c.id
+                LEFT JOIN users u ON qc.qc_officer_id = u.user_id
+                WHERE qc.qc_officer_id = :user_id
+                ORDER BY qc.date DESC, qc.qc_id DESC
+                LIMIT 5
+            ");
+            $qcReportsStmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+            $qcReportsStmt->execute();
+            $lastQcReports = $qcReportsStmt->fetchAll(PDO::FETCH_ASSOC);
+
+            // 2. Passed CHDM records related to user's QC reports
+            $passedChdmStmt = $conn->prepare("
+                SELECT c.id, c.serial_no, c.state, c.location, c.description, c.tested_date,
+                       qc.date as qc_date, qc.result, qc.remarks
+                FROM chdm c
+                INNER JOIN quality_check qc ON c.id = qc.chdm_id
+                WHERE qc.qc_officer_id = :user_id AND c.state = 'passed'
+                ORDER BY qc.date DESC, c.tested_date DESC
+                LIMIT 10
+            ");
+            $passedChdmStmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+            $passedChdmStmt->execute();
+            $passedChdm = $passedChdmStmt->fetchAll(PDO::FETCH_ASSOC);
+
+            // 3. Failed CHDM records related to user's QC reports
+            $failedChdmStmt = $conn->prepare("
+                SELECT c.id, c.serial_no, c.state, c.location, c.description, c.tested_date,
+                       qc.date as qc_date, qc.result, qc.remarks
+                FROM chdm c
+                INNER JOIN quality_check qc ON c.id = qc.chdm_id
+                WHERE qc.qc_officer_id = :user_id AND c.state = 'failed'
+                ORDER BY qc.date DESC, c.tested_date DESC
+                LIMIT 10
+            ");
+            $failedChdmStmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+            $failedChdmStmt->execute();
+            $failedChdm = $failedChdmStmt->fetchAll(PDO::FETCH_ASSOC);
+
+            // 4. Last 5 dispatch records created by the authenticated user
+            $dispatchStmt = $conn->prepare("
+                SELECT d.dispatch_id, d.item_id, d.warehouse_name, d.quantity, d.date, 
+                       d.purpose, d.status,
+                       i.item_name, i.category as item_category,
+                       u.username as qc_officer_name
+                FROM dispatch d
+                LEFT JOIN inventory_item i ON d.item_id = i.item_id
+                LEFT JOIN users u ON d.qc_officer_id = u.user_id
+                WHERE d.qc_officer_id = :user_id
+                ORDER BY d.date DESC, d.dispatch_id DESC
+                LIMIT 5
+            ");
+            $dispatchStmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+            $dispatchStmt->execute();
+            $lastDispatchRecords = $dispatchStmt->fetchAll(PDO::FETCH_ASSOC);
+
+            // 5. Summary statistics for the user
+            $summaryStmt = $conn->prepare("
+                SELECT 
+                    COUNT(DISTINCT qc.qc_id) as total_qc_reports,
+                    SUM(CASE WHEN qc.result = 'passed' THEN 1 ELSE 0 END) as passed_count,
+                    SUM(CASE WHEN qc.result = 'failed' THEN 1 ELSE 0 END) as failed_count,
+                    COUNT(DISTINCT qc.chdm_id) as total_devices_tested
+                FROM quality_check qc
+                WHERE qc.qc_officer_id = :user_id
+            ");
+            $summaryStmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+            $summaryStmt->execute();
+            $qcSummary = $summaryStmt->fetch(PDO::FETCH_ASSOC);
+
+            // 6. Dispatch summary for the user
+            $dispatchSummaryStmt = $conn->prepare("
+                SELECT 
+                    COUNT(DISTINCT d.dispatch_id) as total_dispatches,
+                    SUM(d.quantity) as total_quantity_dispatched,
+                    COUNT(DISTINCT d.item_id) as unique_items_dispatched
+                FROM dispatch d
+                WHERE d.qc_officer_id = :user_id
+            ");
+            $dispatchSummaryStmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+            $dispatchSummaryStmt->execute();
+            $dispatchSummary = $dispatchSummaryStmt->fetch(PDO::FETCH_ASSOC);
+
+            // Calculate pass rate
+            $totalReports = (int)$qcSummary['total_qc_reports'];
+            $passedCount = (int)$qcSummary['passed_count'];
+            $passRate = $totalReports > 0 ? round(($passedCount / $totalReports) * 100, 2) : 0;
+
+            return [
+                'status' => 'success',
+                'user_info' => [
+                    'user_id' => $user_id,
+                    'username' => isset($user['username']) ? $user['username'] : 'Unknown',
+                    'role' => $roleName
+                ],
+                'last_qc_reports' => $lastQcReports,
+                'passed_chdm' => $passedChdm,
+                'failed_chdm' => $failedChdm,
+                'last_dispatch_records' => $lastDispatchRecords,
+                'summary' => [
+                    'qc_reports' => [
+                        'total' => $totalReports,
+                        'passed' => $passedCount,
+                        'failed' => (int)$qcSummary['failed_count'],
+                        'pass_rate_percentage' => $passRate,
+                        'devices_tested' => (int)$qcSummary['total_devices_tested']
+                    ],
+                    'dispatches' => [
+                        'total' => (int)$dispatchSummary['total_dispatches'],
+                        'total_quantity' => (int)$dispatchSummary['total_quantity_dispatched'],
+                        'unique_items' => (int)$dispatchSummary['unique_items_dispatched']
+                    ]
+                ]
+            ];
+
+        } catch(Exception $e) {
+            return [
+                'status' => 'error',
+                'message' => 'QC Dashboard error: ' . $e->getMessage()
+            ];
+        }
+    }
+
+    
+
     /**
      * GET /api/stats/stats/technician_dashboard
      * Returns dashboard data for the authenticated technician

--- a/src/classes/Dispatch.php
+++ b/src/classes/Dispatch.php
@@ -79,6 +79,91 @@ class dispatch extends Model {
         return $dispatches;
     }
 
+    static public function getDispatchesByUser($user_id) {
+        $conn = DatabaseConnection::getConnection();
+        
+        $sql = "SELECT 
+                    d.dispatch_id, 
+                    d.item_id, 
+                    d.warehouse_name, 
+                    d.quantity, 
+                    d.date, 
+                    d.purpose, 
+                    d.status, 
+                    i.item_name, 
+                    u.username AS qc_officer_name
+                FROM 
+                    dispatch d
+                LEFT JOIN 
+                    inventory_item i ON d.item_id = i.item_id
+                LEFT JOIN 
+                    users u ON d.qc_officer_id = u.user_id
+                WHERE 
+                    d.qc_officer_id = :user_id
+                ORDER BY 
+                    d.date DESC, d.dispatch_id DESC";
+                    
+        $stmt = $conn->prepare($sql);
+        $stmt->bindParam(":user_id", $user_id, PDO::PARAM_INT);
+        $stmt->execute();
+        $dispatches = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return $dispatches;
+    }
+
+    static public function getDispatchesByUserPaginated($user_id, $page = 1, $limit = 10) {
+        $conn = DatabaseConnection::getConnection();
+        
+        // Calculate offset
+        $offset = ($page - 1) * $limit;
+        
+        // Get total count
+        $countSql = "SELECT COUNT(*) as total 
+                     FROM dispatch d 
+                     WHERE d.qc_officer_id = :user_id";
+        $countStmt = $conn->prepare($countSql);
+        $countStmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+        $countStmt->execute();
+        $totalCount = $countStmt->fetch(PDO::FETCH_ASSOC)['total'];
+        
+        // Get paginated results
+        $sql = "SELECT 
+                    d.dispatch_id, 
+                    d.item_id, 
+                    d.warehouse_name, 
+                    d.quantity, 
+                    d.date, 
+                    d.purpose, 
+                    d.status, 
+                    i.item_name, 
+                    u.username AS qc_officer_name
+                FROM 
+                    dispatch d
+                LEFT JOIN 
+                    inventory_item i ON d.item_id = i.item_id
+                LEFT JOIN 
+                    users u ON d.qc_officer_id = u.user_id
+                WHERE 
+                    d.qc_officer_id = :user_id
+                ORDER BY 
+                    d.date DESC, d.dispatch_id DESC
+                LIMIT :limit OFFSET :offset";
+                    
+        $stmt = $conn->prepare($sql);
+        $stmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+        $stmt->bindParam(':limit', $limit, PDO::PARAM_INT);
+        $stmt->bindParam(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        $dispatches = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        
+        return [
+            'data' => $dispatches,
+            'total' => $totalCount,
+            'page' => $page,
+            'limit' => $limit,
+            'total_pages' => ceil($totalCount / $limit)
+        ];
+    }
+
     public function update() {
         $conn = DatabaseConnection::getConnection();
         $sql = "UPDATE dispatch SET item_id = :item_id, qc_officer_id = :qc_officer_id, warehouse_name = :warehouse_name, quantity = :quantity, date = :date, purpose = :purpose, status = :status WHERE dispatch_id = :dispatch_id";

--- a/test_qc_dashboard.json
+++ b/test_qc_dashboard.json
@@ -1,0 +1,110 @@
+{
+  "method": "GET",
+  "endpoint": "/api/stats/stats/qc_dashboard",
+  "description": "Test QC Dashboard API endpoint to fetch last 5 QC reports, passed/failed CHDM records, and last 5 dispatch records for authenticated user",
+  "headers": {
+    "Authorization": "Bearer YOUR_JWT_TOKEN_HERE",
+    "Content-Type": "application/json"
+  },
+  "expected_response": {
+    "status": "success",
+    "user_info": {
+      "user_id": "integer",
+      "username": "string",
+      "role": "Quality_Checker|admin|technician"
+    },
+    "last_qc_reports": [
+      {
+        "qc_id": "integer",
+        "chdm_id": "integer",
+        "date": "date",
+        "result": "passed|failed",
+        "remarks": "string",
+        "test_details": "string",
+        "serial_no": "string",
+        "location": "string",
+        "chdm_description": "string",
+        "chdm_state": "passed|failed",
+        "qc_officer_name": "string"
+      }
+    ],
+    "passed_chdm": [
+      {
+        "id": "integer",
+        "serial_no": "string", 
+        "state": "passed",
+        "location": "string",
+        "description": "string",
+        "tested_date": "date",
+        "qc_date": "date",
+        "result": "passed",
+        "remarks": "string"
+      }
+    ],
+    "failed_chdm": [
+      {
+        "id": "integer",
+        "serial_no": "string",
+        "state": "failed", 
+        "location": "string",
+        "description": "string",
+        "tested_date": "date",
+        "qc_date": "date",
+        "result": "failed",
+        "remarks": "string"
+      }
+    ],
+    "last_dispatch_records": [
+      {
+        "dispatch_id": "integer",
+        "item_id": "integer",
+        "warehouse_name": "string",
+        "quantity": "integer",
+        "date": "date",
+        "purpose": "string",
+        "status": "string",
+        "item_name": "string",
+        "item_category": "string",
+        "qc_officer_name": "string"
+      }
+    ],
+    "summary": {
+      "qc_reports": {
+        "total": "integer",
+        "passed": "integer", 
+        "failed": "integer",
+        "pass_rate_percentage": "float",
+        "devices_tested": "integer"
+      },
+      "dispatches": {
+        "total": "integer",
+        "total_quantity": "integer",
+        "unique_items": "integer"
+      }
+    }
+  },
+  "error_responses": {
+    "invalid_token": {
+      "status": "error",
+      "message": "Invalid authentication token"
+    },
+    "unauthorized": {
+      "status": "error", 
+      "message": "Unauthorized: Quality Checker, Admin or Technician access required"
+    },
+    "missing_user_id": {
+      "status": "error",
+      "message": "User ID not found in authentication token"
+    }
+  },
+  "test_instructions": {
+    "1": "Replace YOUR_JWT_TOKEN_HERE with a valid JWT token for a Quality Checker, Admin, or Technician user",
+    "2": "Make a GET request to the endpoint with the Authorization header",
+    "3": "Verify that the response contains all expected fields",
+    "4": "Check that last_qc_reports contains only records created by the authenticated user",
+    "5": "Verify that passed_chdm and failed_chdm only show CHDM records that the user has created QC reports for",
+    "6": "Confirm that last_dispatch_records only shows dispatches created by the authenticated user",
+    "7": "Check that summary statistics are calculated correctly for the user's data only"
+  },
+  "curl_example": "curl -X GET 'http://localhost/api/stats/stats/qc_dashboard' -H 'Authorization: Bearer YOUR_JWT_TOKEN_HERE' -H 'Content-Type: application/json'"
+}


### PR DESCRIPTION
Introduces a QC dashboard API endpoint that returns recent QC reports, passed/failed CHDM records, dispatch records, and summary statistics for the authenticated user. Adds view_my_dispatches API and supporting methods for paginated user dispatch retrieval. Includes a test JSON for the QC dashboard endpoint.